### PR TITLE
Read config to enable UserOperationDataPublisher

### DIFF
--- a/components/org.wso2.carbon.identity.data.publisher.audit.common/src/main/java/org/wso2/carbon/identity/data/publisher/audit/common/AuditDataPublisherConstants.java
+++ b/components/org.wso2.carbon.identity.data.publisher.audit.common/src/main/java/org/wso2/carbon/identity/data/publisher/audit/common/AuditDataPublisherConstants.java
@@ -24,6 +24,7 @@ package org.wso2.carbon.identity.data.publisher.audit.common;
 public class AuditDataPublisherConstants {
     public static final String OVERALL_USER_DATA_EVENT_STREAM_NAME = "org.wso2.is.analytics.stream.OverallUserData:1.0.0";
     public static final String USER_MGT_DAS_DATA_PUBLISHER = "userOperationDataDASPublisher";
+    public static final String USER_MGT_DAS_PUBLISHER_ENABLED_PROPERTY = "userOperationDataDASPublisher.enable";
 
     public static final String IDP_PROPERTIES_UPDATE_EVENT_STREAM_NAME =
             "org.wso2.is.analytics.stream.IdPPropertiesUpdate:1.0.0";

--- a/components/org.wso2.carbon.identity.data.publisher.audit.user.operation/src/main/java/org/wso2/carbon/identity/data/publisher/audit/user/operation/impl/UserOperationDataPublisher.java
+++ b/components/org.wso2.carbon.identity.data.publisher.audit.user.operation/src/main/java/org/wso2/carbon/identity/data/publisher/audit/user/operation/impl/UserOperationDataPublisher.java
@@ -50,6 +50,9 @@ public class UserOperationDataPublisher extends AbstractEventHandler {
     @Override
     public void handleEvent(Event event) throws IdentityEventException {
 
+        if (!isEnabled()) {
+            return;
+        }
         switch (event.getEventName()) {
             case IdentityEventConstants.Event.POST_ADD_USER:
                 handleAddUser(event);
@@ -221,5 +224,15 @@ public class UserOperationDataPublisher extends AbstractEventHandler {
     public String getName() {
 
         return AuditDataPublisherConstants.USER_MGT_DAS_DATA_PUBLISHER;
+    }
+
+    private boolean isEnabled() {
+
+        if (this.configs.getModuleProperties() != null) {
+            String handlerEnabled = this.configs.getModuleProperties().
+                    getProperty(AuditDataPublisherConstants.USER_MGT_DAS_PUBLISHER_ENABLED_PROPERTY);
+            return Boolean.parseBoolean(handlerEnabled);
+        }
+        return false;
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

Resolves a part of issue https://github.com/wso2/product-is/issues/10201

During IS server startup, we could see the following warn logs.

`WARN {org.wso2.carbon.identity.event.internal.IdentityEventServiceComponent} - Properties for userOperationDataDASPublisher is not configured. This event handler will not be activated
`
- This happens since there are no any configuration properties added userOperationDataDASPublisher even though this component is supported OOTB. 

- This PR add a method `isEnabled()` and read the configuration from `identity-event.properties` file.. By default, this `userOperationDataDASPublisher` is disabled in the code-level and in the configuration level

### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


